### PR TITLE
feat: add Metal Q4_0 matmul kernel

### DIFF
--- a/matmul-mini/README.md
+++ b/matmul-mini/README.md
@@ -1,0 +1,10 @@
+# Matmul Mini
+
+Minimal extraction of GGML matrix multiplication routines.
+
+Currently includes:
+
+* CPU backend covering F32, F16, BF16 and Q4_0 weights with simple threaded chunking
+* Metal backend with Q4_0 quantized matrix-matrix kernel
+
+More backends (additional quantization, CUDA) to be added.

--- a/matmul-mini/common/ggml_common.h
+++ b/matmul-mini/common/ggml_common.h
@@ -1,0 +1,75 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// basic 16-bit floating point types
+typedef uint16_t ggml_half;
+typedef uint16_t ggml_bf16_t;
+
+#define QK4_0 32
+
+typedef struct {
+    ggml_half d;
+    uint8_t   qs[QK4_0/2];
+} block_q4_0;
+
+enum ggml_type {
+    GGML_TYPE_F32 = 0,
+    GGML_TYPE_F16,
+    GGML_TYPE_BF16,
+    GGML_TYPE_Q4_0,
+    GGML_TYPE_COUNT,
+};
+
+struct ggml_tensor {
+    enum ggml_type type;
+    int64_t ne[4];
+    size_t  nb[4];
+    void *  data;
+    struct ggml_tensor * src[2];
+};
+
+static inline size_t ggml_type_size(enum ggml_type type) {
+    switch (type) {
+        case GGML_TYPE_F32:  return sizeof(float);
+        case GGML_TYPE_F16:  return sizeof(ggml_half);
+        case GGML_TYPE_BF16: return sizeof(ggml_bf16_t);
+        case GGML_TYPE_Q4_0: return sizeof(block_q4_0);
+        default: return 0;
+    }
+}
+
+static inline size_t ggml_blck_size(enum ggml_type type) {
+    switch (type) {
+        case GGML_TYPE_Q4_0: return QK4_0;
+        default: return 1;
+    }
+}
+
+static inline size_t ggml_row_size(enum ggml_type type, int64_t ne) {
+    const size_t ts = ggml_type_size(type);
+    const size_t bs = ggml_blck_size(type);
+    return ts * (ne / bs);
+}
+
+static inline bool ggml_is_contiguous(const struct ggml_tensor * t) {
+    return t->nb[0] == ggml_type_size(t->type);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/matmul-mini/cpu/matmul_cpu.c
+++ b/matmul-mini/cpu/matmul_cpu.c
@@ -1,0 +1,186 @@
+#include "matmul_cpu.h"
+#include <math.h>
+#include <stdlib.h>
+
+static inline float fp16_to_fp32(ggml_half h) {
+    uint32_t sign = (h & 0x8000) << 16;
+    uint32_t exp  = (h & 0x7C00) >> 10;
+    uint32_t mant = (h & 0x03FF);
+    uint32_t bits;
+    if (exp == 0) {
+        if (mant == 0) {
+            bits = sign;
+        } else {
+            exp = 1;
+            while ((mant & 0x0400) == 0) { mant <<= 1; exp--; }
+            mant &= 0x03FF;
+            bits = sign | ((exp + 112) << 23) | (mant << 13);
+        }
+    } else if (exp == 31) {
+        bits = sign | 0x7F800000 | (mant << 13);
+    } else {
+        bits = sign | ((exp + 112) << 23) | (mant << 13);
+    }
+    float f;
+    memcpy(&f, &bits, sizeof(f));
+    return f;
+}
+
+static inline ggml_half fp32_to_fp16(float f) {
+    uint32_t bits; memcpy(&bits, &f, sizeof(bits));
+    uint32_t sign = (bits >> 16) & 0x8000;
+    int exp = ((bits >> 23) & 0xFF) - 127 + 15;
+    uint32_t mant = bits & 0x7FFFFF;
+    if (exp <= 0) {
+        return sign;
+    } else if (exp >= 31) {
+        return sign | 0x7C00;
+    } else {
+        return sign | ((exp & 0x1F) << 10) | (mant >> 13);
+    }
+}
+
+static inline float bf16_to_fp32(ggml_bf16_t h) {
+    uint32_t u = ((uint32_t)h) << 16;
+    float f; memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+static inline ggml_bf16_t fp32_to_bf16(float f) {
+    uint32_t u; memcpy(&u, &f, sizeof(u));
+    return (ggml_bf16_t)(u >> 16);
+}
+
+void ggml_cpu_fp32_to_fp32(const float * x, void * y, int64_t n) {
+    memcpy(y, x, n * sizeof(float));
+}
+
+void ggml_cpu_fp32_to_fp16(const float * x, void * y, int64_t n) {
+    ggml_half * yy = (ggml_half *)y;
+    for (int64_t i = 0; i < n; ++i) {
+        yy[i] = fp32_to_fp16(x[i]);
+    }
+}
+
+void ggml_cpu_fp32_to_bf16(const float * x, void * y, int64_t n) {
+    ggml_bf16_t * yy = (ggml_bf16_t *)y;
+    for (int64_t i = 0; i < n; ++i) {
+        yy[i] = fp32_to_bf16(x[i]);
+    }
+}
+
+void quantize_row_q4_0(const float * x, void * vy, int64_t k) {
+    block_q4_0 * y = (block_q4_0 *)vy;
+    int nb = k / QK4_0;
+    for (int i = 0; i < nb; ++i) {
+        float amax = 0.0f;
+        float maxv = 0.0f;
+        for (int j = 0; j < QK4_0; ++j) {
+            float v = x[i*QK4_0 + j];
+            if (fabsf(v) > amax) { amax = fabsf(v); maxv = v; }
+        }
+        float d = maxv / -8.0f;
+        float id = d ? 1.0f/d : 0.0f;
+        y[i].d = fp32_to_fp16(d);
+        for (int j = 0; j < QK4_0/2; ++j) {
+            float x0 = x[i*QK4_0 + j] * id;
+            float x1 = x[i*QK4_0 + QK4_0/2 + j] * id;
+            uint8_t xi0 = (uint8_t) (fminf(15.f, floorf(x0 + 8.5f)));
+            uint8_t xi1 = (uint8_t) (fminf(15.f, floorf(x1 + 8.5f)));
+            y[i].qs[j] = xi0 | (xi1 << 4);
+        }
+    }
+}
+
+void ggml_vec_dot_f32(int n, float * s, size_t bs, const float * x, size_t bx, const float * y, size_t by, int nrc) {
+    (void)bs; (void)bx; (void)by; (void)nrc;
+    float sum = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        sum += x[i] * y[i];
+    }
+    *s = sum;
+}
+
+void ggml_vec_dot_f16(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {
+    (void)bs; (void)bx; (void)by; (void)nrc;
+    const ggml_half * x = (const ggml_half *)vx;
+    const float * y = (const float *)vy;
+    float sum = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        sum += fp16_to_fp32(x[i]) * y[i];
+    }
+    *s = sum;
+}
+
+void ggml_vec_dot_bf16(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {
+    (void)bs; (void)bx; (void)by; (void)nrc;
+    const ggml_bf16_t * x = (const ggml_bf16_t *)vx;
+    const float * y = (const float *)vy;
+    float sum = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        sum += bf16_to_fp32(x[i]) * y[i];
+    }
+    *s = sum;
+}
+
+void ggml_vec_dot_q4_0(int n, float * s, size_t bs, const void * vx, size_t bx, const void * vy, size_t by, int nrc) {
+    (void)bs; (void)bx; (void)by; (void)nrc;
+    const block_q4_0 * x = (const block_q4_0 *)vx;
+    const float * y = (const float *)vy;
+    int nb = n / QK4_0;
+    float sum = 0.0f;
+    for (int i = 0; i < nb; ++i) {
+        float d = fp16_to_fp32(x[i].d);
+        for (int j = 0; j < QK4_0/2; ++j) {
+            uint8_t q = x[i].qs[j];
+            float v0 = ((q & 0x0F) - 8) * d;
+            float v1 = ((q >> 4) - 8) * d;
+            sum += v0 * y[i*QK4_0 + j];
+            sum += v1 * y[i*QK4_0 + QK4_0/2 + j];
+        }
+    }
+    *s = sum;
+}
+
+const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
+    [GGML_TYPE_F32]  = { ggml_cpu_fp32_to_fp32, (ggml_vec_dot_t)ggml_vec_dot_f32,  GGML_TYPE_F32, 1 },
+    [GGML_TYPE_F16]  = { ggml_cpu_fp32_to_fp16, ggml_vec_dot_f16,                GGML_TYPE_F32, 1 },
+    [GGML_TYPE_BF16] = { ggml_cpu_fp32_to_bf16, ggml_vec_dot_bf16,               GGML_TYPE_F32, 1 },
+    [GGML_TYPE_Q4_0] = { quantize_row_q4_0,     ggml_vec_dot_q4_0,               GGML_TYPE_F32, 1 },
+};
+
+static void ggml_compute_forward_mul_mat_one_chunk(
+        const struct ggml_tensor * a,
+        const struct ggml_tensor * b,
+        struct ggml_tensor * dst,
+        int64_t ir0_start, int64_t ir0_end,
+        int64_t ir1_start, int64_t ir1_end) {
+    const int64_t k = a->ne[0];
+    for (int64_t i = ir0_start; i < ir0_end; ++i) {
+        float * out = (float *)dst->data + i*b->ne[1];
+        const char * ap = (const char *)a->data + i * a->nb[1];
+        for (int64_t j = ir1_start; j < ir1_end; ++j) {
+            const char * bp = (const char *)b->data + j * b->nb[1];
+            float sum = 0.0f;
+            type_traits_cpu[a->type].vec_dot(k, &sum, 0, ap, a->nb[0], bp, b->nb[0], 1);
+            out[j] = sum;
+        }
+    }
+}
+
+void ggml_compute_forward_mul_mat(const struct ggml_compute_params * params,
+                                  struct ggml_tensor * dst) {
+    const struct ggml_tensor * a = dst->src[0];
+    const struct ggml_tensor * b = dst->src[1];
+
+    const int64_t m = a->ne[1];
+    const int64_t n = b->ne[1];
+    const int ith = params->ith;
+    const int nth = params->nth;
+
+    const int64_t dr = (m + nth - 1) / nth;
+    const int64_t ir0_start = MIN(ith * dr, m);
+    const int64_t ir0_end   = MIN(ir0_start + dr, m);
+
+    ggml_compute_forward_mul_mat_one_chunk(a, b, dst, ir0_start, ir0_end, 0, n);
+}

--- a/matmul-mini/cpu/matmul_cpu.h
+++ b/matmul-mini/cpu/matmul_cpu.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include <string.h>
+#include "../common/ggml_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*ggml_from_float_t)(const float *, void *, int64_t);
+typedef void (*ggml_vec_dot_t)(int, float *, size_t, const void *, size_t, const void *, size_t, int);
+
+struct ggml_threadpool {
+    _Atomic int current_chunk;
+};
+
+struct ggml_compute_params {
+    int ith, nth;
+    size_t wsize;
+    char * wdata;
+    struct ggml_threadpool * threadpool;
+};
+
+struct ggml_type_traits_cpu {
+    ggml_from_float_t from_float;
+    ggml_vec_dot_t vec_dot;
+    enum ggml_type vec_dot_type;
+    int64_t nrows;
+};
+
+extern const struct ggml_type_traits_cpu type_traits_cpu[];
+
+void ggml_vec_dot_f32(int n, float * s, size_t bs, const float * x, size_t bx, const float * y, size_t by, int nrc);
+void ggml_cpu_fp32_to_fp32(const float * x, void * y, int64_t n);
+void ggml_cpu_fp32_to_fp16(const float * x, void * y, int64_t n);
+void ggml_cpu_fp32_to_bf16(const float * x, void * y, int64_t n);
+void quantize_row_q4_0(const float * x, void * y, int64_t k);
+void ggml_vec_dot_f16(int n, float * s, size_t bs, const void * x, size_t bx, const void * y, size_t by, int nrc);
+void ggml_vec_dot_bf16(int n, float * s, size_t bs, const void * x, size_t bx, const void * y, size_t by, int nrc);
+void ggml_vec_dot_q4_0(int n, float * s, size_t bs, const void * x, size_t bx, const void * y, size_t by, int nrc);
+
+void ggml_compute_forward_mul_mat(const struct ggml_compute_params * params,
+                                  struct ggml_tensor * dst);
+
+#ifdef __cplusplus
+}
+#endif

--- a/matmul-mini/metal/matmul_metal.h
+++ b/matmul-mini/metal/matmul_metal.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../common/ggml_common.h"
+#include "metal_impl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ggml_metal_context;
+
+struct ggml_metal_context * ggml_metal_init(void);
+void ggml_metal_free(struct ggml_metal_context * ctx);
+
+void ggml_metal_mul_mm_q4_0_f32(struct ggml_metal_context * ctx,
+                                const struct ggml_tensor * src0,
+                                const struct ggml_tensor * src1,
+                                struct ggml_tensor * dst);
+
+#ifdef __cplusplus
+}
+#endif

--- a/matmul-mini/metal/matmul_metal.m
+++ b/matmul-mini/metal/matmul_metal.m
@@ -1,0 +1,73 @@
+#import "matmul_metal.h"
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+struct ggml_metal_context {
+    id<MTLDevice> device;
+    id<MTLLibrary> library;
+    id<MTLCommandQueue> queue;
+    id<MTLComputePipelineState> mul_mm_q4_0_f32;
+};
+
+struct ggml_metal_context * ggml_metal_init(void) {
+    struct ggml_metal_context * ctx = calloc(1, sizeof(*ctx));
+    ctx->device = MTLCreateSystemDefaultDevice();
+    ctx->queue  = [ctx->device newCommandQueue];
+
+    NSError * err = nil;
+    NSString * src = [NSString stringWithContentsOfFile:@"matmul-mini/metal/matmul_metal.metal" encoding:NSUTF8StringEncoding error:&err];
+    ctx->library = [ctx->device newLibraryWithSource:src options:nil error:&err];
+    id<MTLFunction> fn = [ctx->library newFunctionWithName:@"kernel_mul_mm_q4_0_f32"];
+    ctx->mul_mm_q4_0_f32 = [ctx->device newComputePipelineStateWithFunction:fn error:&err];
+    return ctx;
+}
+
+void ggml_metal_free(struct ggml_metal_context * ctx) {
+    if (!ctx) return;
+    [ctx->queue release];
+    [ctx->library release];
+    [ctx->device release];
+    free(ctx);
+}
+
+void ggml_metal_mul_mm_q4_0_f32(struct ggml_metal_context * ctx,
+                                const struct ggml_tensor * src0,
+                                const struct ggml_tensor * src1,
+                                struct ggml_tensor * dst) {
+    id<MTLBuffer> id_src0 = (__bridge id<MTLBuffer>) src0->data;
+    id<MTLBuffer> id_src1 = (__bridge id<MTLBuffer>) src1->data;
+    id<MTLBuffer> id_dst  = (__bridge id<MTLBuffer>) dst->data;
+
+    ggml_metal_kargs_mul_mm args = {
+        (int32_t) src0->ne[0],
+        (int32_t) src0->ne[2],
+        src0->nb[1],
+        src0->nb[2],
+        src0->nb[3],
+        (int32_t) src1->ne[2],
+        src1->nb[0],
+        src1->nb[1],
+        src1->nb[2],
+        src1->nb[3],
+        (int32_t) dst->ne[0],
+        (int32_t) dst->ne[1],
+        1,
+        1,
+    };
+
+    id<MTLCommandBuffer> cb = [ctx->queue commandBuffer];
+    id<MTLComputeCommandEncoder> encoder = [cb computeCommandEncoder];
+    [encoder setComputePipelineState:ctx->mul_mm_q4_0_f32];
+    [encoder setBytes:&args length:sizeof(args) atIndex:0];
+    [encoder setBuffer:id_src0 offset:0 atIndex:1];
+    [encoder setBuffer:id_src1 offset:0 atIndex:2];
+    [encoder setBuffer:id_dst  offset:0 atIndex:3];
+    [encoder setThreadgroupMemoryLength:8192 atIndex:0];
+
+    MTLSize tg = MTLSizeMake((src1->ne[1] + 31)/32, (src0->ne[1] + 63)/64, src1->ne[2]*src1->ne[3]);
+    MTLSize tp = MTLSizeMake(128, 1, 1);
+    [encoder dispatchThreadgroups:tg threadsPerThreadgroup:tp];
+    [encoder endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+}

--- a/matmul-mini/metal/matmul_metal.metal
+++ b/matmul-mini/metal/matmul_metal.metal
@@ -1,0 +1,195 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#define QK4_0 32
+
+typedef matrix<float,4,4> float4x4;
+typedef matrix<half,4,4>  half4x4;
+typedef simdgroup_matrix<half,8,8> simdgroup_half8x8;
+
+typedef struct {
+    half d;
+    uint8_t qs[QK4_0 / 2];
+} block_q4_0;
+
+struct ggml_metal_kargs_mul_mm {
+    int32_t  ne00;
+    int32_t  ne02;
+    uint64_t nb01;
+    uint64_t nb02;
+    uint64_t nb03;
+    int32_t  ne12;
+    uint64_t nb10;
+    uint64_t nb11;
+    uint64_t nb12;
+    uint64_t nb13;
+    int32_t  ne0;
+    int32_t  ne1;
+    int16_t  r2;
+    int16_t  r3;
+};
+
+// NOTE: this is not dequantizing - we are simply fitting the template
+// from ggml's metal backend
+
+template <typename type4x4>
+void dequantize_f32(device const float4x4 * src, short il, thread type4x4 & reg) {
+    reg = (type4x4)(*src);
+}
+
+template <typename type4x4>
+void dequantize_q4_0(device const block_q4_0 * xb, short il, thread type4x4 & reg) {
+    device const uint16_t * qs = ((device const uint16_t *)xb + 1);
+    const float d1 = il ? (xb->d / 16.h) : xb->d;
+    const float d2 = d1 / 256.f;
+    const float md = -8.h * xb->d;
+    const ushort mask0 = il ? 0x00F0 : 0x000F;
+    const ushort mask1 = mask0 << 8;
+    float4x4 reg_f;
+    for (int i = 0; i < 8; i++) {
+        reg_f[i/2][2*(i%2) + 0] = d1 * (qs[i] & mask0) + md;
+        reg_f[i/2][2*(i%2) + 1] = d2 * (qs[i] & mask1) + md;
+    }
+    reg = (type4x4) reg_f;
+}
+
+#define BLOCK_SIZE_M 64
+#define BLOCK_SIZE_N 32
+#define BLOCK_SIZE_K 32
+#define THREAD_MAT_M 4
+#define THREAD_MAT_N 2
+#define THREAD_PER_BLOCK 128
+#define THREAD_PER_ROW 2
+#define THREAD_PER_COL 4
+#define SG_MAT_SIZE 64
+#define SG_MAT_ROW 8
+
+template<typename T, typename T4x4, typename simdgroup_T8x8, typename block_q, short nl, void (*dequantize_func)(device const block_q *, short, thread T4x4 &)> 
+kernel void kernel_mul_mm(
+        constant ggml_metal_kargs_mul_mm & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiitg[[thread_index_in_threadgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+
+    threadgroup T     * sa = (threadgroup T     *)(shmem);
+    threadgroup float * sb = (threadgroup float *)(shmem + 4096);
+
+    const int r0 = tgpig.y;
+    const int r1 = tgpig.x;
+    const int im = tgpig.z;
+
+    const short n_rows = (args.ne0 - r0*BLOCK_SIZE_M < BLOCK_SIZE_M) ? (args.ne0 - r0*BLOCK_SIZE_M) : BLOCK_SIZE_M;
+    const short n_cols = (args.ne1 - r1*BLOCK_SIZE_N < BLOCK_SIZE_N) ? (args.ne1 - r1*BLOCK_SIZE_N) : BLOCK_SIZE_N;
+
+    const short thread_row = ((short)tiitg/THREAD_PER_ROW) < n_rows ? ((short)tiitg/THREAD_PER_ROW) : n_rows - 1;
+    const short thread_col = ((short)tiitg/THREAD_PER_COL) < n_cols ? ((short)tiitg/THREAD_PER_COL) : n_cols - 1;
+
+    simdgroup_T8x8     ma[4];
+    simdgroup_float8x8 mb[2];
+    simdgroup_float8x8 mc[8];
+
+    for (short i = 0; i < 8; i++){ mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f); }
+
+    short il = (tiitg % THREAD_PER_ROW);
+
+    const int i12 = im%args.ne12;
+    const int i13 = im/args.ne12;
+
+    const uint64_t offset0 = (i12/args.r2)*args.nb02 + (i13/args.r3)*args.nb03;
+    const short    offset1 = il/nl;
+
+    device const block_q * x = (device const block_q *)(src0 + args.nb01*(r0*BLOCK_SIZE_M + thread_row) + offset0) + offset1;
+    device const float   * y = (device const float   *)(src1 + args.nb13*i13 + args.nb12*i12 + args.nb11*(r1*BLOCK_SIZE_N + thread_col) + args.nb10*(BLOCK_SIZE_K / THREAD_PER_COL * (tiitg % THREAD_PER_COL)));
+
+    for (int loop_k = 0; loop_k < args.ne00; loop_k += BLOCK_SIZE_K) {
+        T4x4 temp_a;
+        dequantize_func(x, il, temp_a);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        #pragma unroll(16)
+        for (short i = 0; i < 16; i++) {
+            *(sa + SG_MAT_SIZE * ((tiitg/THREAD_PER_ROW/8)
+            +                     (tiitg%THREAD_PER_ROW)*16 + (i/8)*8)
+            +                     (tiitg/THREAD_PER_ROW)%8  + (i&7)*8) = temp_a[i/4][i%4];
+        }
+
+        *(threadgroup float2x4 *)(sb + 32*8*(tiitg%THREAD_PER_COL) + 8*(tiitg/THREAD_PER_COL)) = *((device float2x4 *) y);
+
+        il = (il + 2 < nl) ? il + 2 : il % 2;
+        x  = (il < 2) ? x + (2 + nl - 1)/nl : x;
+        y += BLOCK_SIZE_K;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        threadgroup const T     * lsma = (sa + THREAD_MAT_M*SG_MAT_SIZE*(sgitg%2));
+        threadgroup const float * lsmb = (sb + THREAD_MAT_N*SG_MAT_SIZE*(sgitg/2));
+
+        #pragma unroll(4)
+        for (short ik = 0; ik < BLOCK_SIZE_K/8; ik++) {
+            #pragma unroll(4)
+            for (short i = 0; i < 4; i++) {
+                simdgroup_load(ma[i], lsma + SG_MAT_SIZE * i);
+            }
+
+            simdgroup_barrier(mem_flags::mem_none);
+
+            #pragma unroll(2)
+            for (short i = 0; i < 2; i++) {
+                simdgroup_load(mb[i], lsmb + SG_MAT_SIZE * i);
+            }
+
+            #pragma unroll(8)
+            for (short i = 0; i < 8; i++){
+                simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
+            }
+
+            lsma += (BLOCK_SIZE_M/SG_MAT_ROW)*SG_MAT_SIZE;
+            lsmb += (BLOCK_SIZE_N/SG_MAT_ROW)*SG_MAT_SIZE;
+        }
+    }
+
+    if ((r0 + 1) * BLOCK_SIZE_M <= args.ne0 && (r1 + 1) * BLOCK_SIZE_N <= args.ne1) {
+        device float * C = (device float *) dst + (BLOCK_SIZE_M * r0 + 32*(sgitg &  1)) + (BLOCK_SIZE_N * r1 + 16*(sgitg >> 1)) * args.ne0 + im*args.ne1*args.ne0;
+        for (short i = 0; i < 8; i++) {
+            simdgroup_store(mc[i], C + 8 * (i%4) + 8 * args.ne0 * (i/4), args.ne0);
+        }
+    } else {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup float * temp_str = ((threadgroup float *) shmem) + 32*(sgitg&1) + (16*(sgitg >> 1))*BLOCK_SIZE_M;
+        for (short i = 0; i < 8; i++) {
+            simdgroup_store(mc[i], temp_str + 8*(i%4) + 8*BLOCK_SIZE_M*(i/4), BLOCK_SIZE_M);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (sgitg == 0) {
+            for (int j = tiitg; j < n_cols; j += BLOCK_SIZE_N) {
+                device float  * D  = (device float  *) dst + (r0*BLOCK_SIZE_M) + (r1*BLOCK_SIZE_N + j)*args.ne0 + im*args.ne1*args.ne0;
+                device float4 * D4 = (device float4 *) D;
+
+                threadgroup float  * C  = temp_str + (j*BLOCK_SIZE_M);
+                threadgroup float4 * C4 = (threadgroup float4 *) C;
+
+                int i = 0;
+                for (; i < n_rows/4; i++) {
+                    *(D4 + i) = *(C4 + i);
+                }
+
+                i *= 4;
+                for (; i < n_rows; i++) {
+                    *(D + i) = *(C + i);
+                }
+            }
+        }
+    }
+}
+
+typedef decltype(kernel_mul_mm<half, half4x4, simdgroup_half8x8, float4x4, 1, dequantize_f32>) mul_mm_t;
+
+template [[host_name("kernel_mul_mm_q4_0_f32")]]
+kernel mul_mm_t kernel_mul_mm<half, half4x4, simdgroup_half8x8, block_q4_0, 2, dequantize_q4_0>;

--- a/matmul-mini/metal/metal_impl.h
+++ b/matmul-mini/metal/metal_impl.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+
+struct ggml_metal_kargs_mul_mm {
+    int32_t  ne00;
+    int32_t  ne02;
+    uint64_t nb01;
+    uint64_t nb02;
+    uint64_t nb03;
+    int32_t  ne12;
+    uint64_t nb10;
+    uint64_t nb11;
+    uint64_t nb12;
+    uint64_t nb13;
+    int32_t  ne0;
+    int32_t  ne1;
+    int16_t  r2;
+    int16_t  r3;
+};

--- a/tests/cpu_matmul_test.c
+++ b/tests/cpu_matmul_test.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include "../matmul-mini/common/ggml_common.h"
+#include "../matmul-mini/cpu/matmul_cpu.h"
+
+int main(void) {
+    const int k = 32;
+    float a[k];
+    float b[k];
+    for (int i = 0; i < k; ++i) {
+        a[i] = sinf((float)i);
+        b[i] = cosf((float)i);
+    }
+
+    struct ggml_tensor ta = {
+        .type = GGML_TYPE_F32,
+        .ne = {k,1,1,1},
+        .nb = {sizeof(float), k*sizeof(float),0,0},
+        .data = a,
+        .src = {NULL, NULL}
+    };
+    struct ggml_tensor tb = {
+        .type = GGML_TYPE_F32,
+        .ne = {k,1,1,1},
+        .nb = {sizeof(float), k*sizeof(float),0,0},
+        .data = b,
+        .src = {NULL, NULL}
+    };
+    float c_f32 = 0.0f;
+    struct ggml_tensor tc = {
+        .type = GGML_TYPE_F32,
+        .ne = {1,1,1,1},
+        .nb = {sizeof(float), sizeof(float),0,0},
+        .data = &c_f32,
+        .src = {&ta, &tb}
+    };
+    struct ggml_compute_params params = {0,1,0,NULL,NULL};
+    ggml_compute_forward_mul_mat(&params, &tc);
+
+    size_t row = ggml_row_size(GGML_TYPE_Q4_0, k);
+    block_q4_0 *aq = (block_q4_0 *)malloc(row);
+    quantize_row_q4_0(a, aq, k);
+    struct ggml_tensor taq = {
+        .type = GGML_TYPE_Q4_0,
+        .ne = {k,1,1,1},
+        .nb = {sizeof(block_q4_0), row,0,0},
+        .data = aq,
+        .src = {NULL, NULL}
+    };
+    float c_q = 0.0f;
+    struct ggml_tensor tcq = {
+        .type = GGML_TYPE_F32,
+        .ne = {1,1,1,1},
+        .nb = {sizeof(float), sizeof(float),0,0},
+        .data = &c_q,
+        .src = {&taq, &tb}
+    };
+    ggml_compute_forward_mul_mat(&params, &tcq);
+
+    printf("%f\n%f\n", c_f32, c_q);
+    free(aq);
+    return 0;
+}

--- a/tests/q4_0_utils.py
+++ b/tests/q4_0_utils.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+QK4_0 = 32
+
+def quantize_row_q4_0_ref(x):
+    assert x.shape[0] % QK4_0 == 0
+    nb = x.shape[0] // QK4_0
+    blocks = []
+    for i in range(nb):
+        block = x[i*QK4_0:(i+1)*QK4_0]
+        amax_index = np.argmax(np.abs(block))
+        maxv = block[amax_index]
+        d = maxv / -8.0
+        id = 1.0 / d if d != 0 else 0.0
+        qs = np.empty(QK4_0 // 2, dtype=np.uint8)
+        for j in range(QK4_0 // 2):
+            x0 = block[j] * id
+            x1 = block[j + QK4_0 // 2] * id
+            xi0 = min(15, int(x0 + 8.5))
+            xi1 = min(15, int(x1 + 8.5))
+            qs[j] = np.uint8(xi0 | (xi1 << 4))
+        blocks.append((d, qs))
+    return blocks
+
+def dequantize_row_q4_0(blocks):
+    y = np.empty(len(blocks) * QK4_0, dtype=np.float32)
+    for i, (d, qs) in enumerate(blocks):
+        for j, byte in enumerate(qs):
+            x0 = (byte & 0x0F) - 8
+            x1 = (byte >> 4) - 8
+            y[i*QK4_0 + j] = x0 * d
+            y[i*QK4_0 + j + QK4_0//2] = x1 * d
+    return y

--- a/tests/test_matmul_cpu.py
+++ b/tests/test_matmul_cpu.py
@@ -1,0 +1,23 @@
+import subprocess
+import numpy as np
+from pathlib import Path
+from q4_0_utils import quantize_row_q4_0_ref, dequantize_row_q4_0, QK4_0
+
+SRC = Path('tests/cpu_matmul_test.c')
+
+def test_cpu_matmul_matches_reference(tmp_path):
+    exe = tmp_path / 'cpu_matmul_test'
+    subprocess.run(['gcc', str(SRC), 'matmul-mini/cpu/matmul_cpu.c', '-I.', '-std=c11', '-lm', '-o', str(exe)], check=True)
+    out = subprocess.check_output([str(exe)]).decode().strip().splitlines()
+    c_f32 = float(out[0])
+    c_q = float(out[1])
+
+    k = QK4_0
+    a = np.sin(np.arange(k, dtype=np.float32))
+    b = np.cos(np.arange(k, dtype=np.float32))
+    ref = float(np.dot(a, b))
+    blocks = quantize_row_q4_0_ref(a)
+    a_deq = dequantize_row_q4_0(blocks)
+    ref_q = float(np.dot(a_deq, b))
+    assert abs(c_f32 - ref) < 1e-5
+    assert abs(c_q - ref_q) < 1.0

--- a/tests/test_matmul_q4_0.py
+++ b/tests/test_matmul_q4_0.py
@@ -1,0 +1,20 @@
+import numpy as np
+from pathlib import Path
+from q4_0_utils import QK4_0, quantize_row_q4_0_ref, dequantize_row_q4_0
+
+def test_q4_0_matmul_matches_fp32():
+    rng = np.random.default_rng(0)
+    m, k, n = 2, QK4_0, 3
+    a_full = rng.standard_normal((m, k), dtype=np.float32)
+    b = rng.standard_normal((k, n), dtype=np.float32)
+
+    blocks = [quantize_row_q4_0_ref(row) for row in a_full]
+    a_deq = np.vstack([dequantize_row_q4_0(row_blocks) for row_blocks in blocks])
+
+    c_ref = a_full @ b
+    c_q = a_deq @ b
+    assert np.max(np.abs(c_ref - c_q)) < 1.0
+
+def test_metal_kernel_symbol_exists():
+    metal_shader = Path('matmul-mini/metal/matmul_metal.metal').read_text()
+    assert 'kernel_mul_mm_q4_0_f32' in metal_shader


### PR DESCRIPTION
## Summary
- add shared tensor/type header with F16/BF16/Q4_0 support
- implement CPU backend covering F32, F16, BF16 and Q4_0 matmul with threaded chunking
- document expanded CPU coverage and add tests compiling a reference program
- cover Q4_0 quantization and Metal shader symbol with a minimal test

## Testing
- `pytest tests/test_matmul_cpu.py -q`
- `pytest tests/test_matmul_q4_0.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68968d4759fc8332ad9a6184de8736ed